### PR TITLE
Add missing includes to avoid FTBFS with gcc 4.7

### DIFF
--- a/gpt/src/GPT.cpp
+++ b/gpt/src/GPT.cpp
@@ -37,6 +37,7 @@
 #include <fstream>
 #include <sstream>
 #include <iostream>
+#include <unistd.h>
 
 GPT* GPT::_self = 0;
 

--- a/gpt/src/modules/interpreter/InterpreterDBG.cpp
+++ b/gpt/src/modules/interpreter/InterpreterDBG.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <pcrecpp.h>
+#include <unistd.h>
 
 #ifndef WIN32
   void sigPipeHandler(int signum) {


### PR DESCRIPTION
Patch by: gregor herrmann <gregoa@debian.org>